### PR TITLE
fix security issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,10 @@ RUN git config --global url."https://github.com/".insteadOf git@github.com: && \
     
 # Install merge-descriptors
 RUN npm install --global merge-descriptors
-    
+
+# update globals
+RUN npm update --global
+
 # OS information to file
 RUN echo "IMAGE INFORMATION" > KTH_OS
 RUN echo "Alpine version: `cat /etc/alpine-release `" >> KTH_OS

--- a/tests/unit-tests/unit-tests.sh
+++ b/tests/unit-tests/unit-tests.sh
@@ -76,7 +76,7 @@ echo ""
 echo "Node JS"
 expectFileToContain "/KTH_NODEJS" "Build date:" "/KTH_NODEJS should contain the date when the images was built."
 expectFileToContain "/KTH_NODEJS" "Node: v16" "Image should have Node v16* installed."
-expectFileToContain "/KTH_NODEJS" 'NPM: 8.' "Image should have 'npm 8.*.*' installed."
+expectFileToContain "/KTH_NODEJS" 'NPM: 9.' "Image should have 'npm 9.*.*' installed."
 expectFileToContain "/KTH_NODEJS" "Yarn: 1." "Image should have 'Yarn 1.*.*' installed."
 expectFileToContain "/KTH_NODEJS" "merge-descriptors@" "Image should have global package 'merge-descriptors' installed."
 


### PR DESCRIPTION
This PR aims to fix the currently security issues that exists in the docker image `kthse/kth-nodejs:16.0.0``

The node and npm versions are upgraded from:
> Node: v16.19.0 -> v16.19.1
> NPM: 8.19.3 ->   9.6.0

(Yarn: 1.22.19 is unchanged)

This resolves a total of: 31 vulnerabilities

For detailed infomation see below
---

### Scan results from current image 
`docker pull kthse/kth-nodejs:16.0.0`

```bash
ᐅ  docker run kthse/kth-nodejs:16.0.0 cat /KTH_NODEJS 
IMAGE INFORMATION
Based on:  node:16-alpine
Build date: Fri Jan 13 00:15:22 UTC 2023
Node: v16.19.0
NPM: 8.19.3
Yarn: 1.22.19

--- Default global packages ---
/usr/local/lib
+-- corepack@0.15.1
+-- merge-descriptors@1.0.1
`-- npm@8.19.3
```
### image scan results:
ᐅ  trivy image kthse/kth-nodejs:16.0.0
Total: 31 (UNKNOWN: 0, LOW: 0, MEDIUM: 9, HIGH: 18, CRITICAL: 4)

<details><summary>Scan details</summary>
<p>

```ruby
2023-03-06T10:49:05.644+0100	INFO	Vulnerability scanning is enabled
2023-03-06T10:49:05.644+0100	INFO	Secret scanning is enabled
2023-03-06T10:49:05.644+0100	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-03-06T10:49:05.644+0100	INFO	Please see also https://aquasecurity.github.io/trivy/v0.38/docs/secret/scanning/#recommendation for faster secret detection
2023-03-06T10:49:07.638+0100	INFO	Detected OS: alpine
2023-03-06T10:49:07.638+0100	INFO	Detecting Alpine vulnerabilities...
2023-03-06T10:49:07.640+0100	INFO	Number of language-specific files: 1
2023-03-06T10:49:07.640+0100	INFO	Detecting node-pkg vulnerabilities...

kthse/kth-nodejs:16.0.0 (alpine 3.17.1)

Total: 31 (UNKNOWN: 0, LOW: 0, MEDIUM: 9, HIGH: 18, CRITICAL: 4)

┌────────────┬────────────────┬──────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                            Title                             │
├────────────┼────────────────┼──────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ curl       │ CVE-2023-23914 │ CRITICAL │ 7.87.0-r1         │ 7.87.0-r2     │ curl: HSTS ignored on multiple requests                      │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-23914                   │
│            ├────────────────┼──────────┤                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-23916 │ HIGH     │                   │               │ curl: HTTP multi-header compression denial of service        │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-23916                   │
│            ├────────────────┼──────────┤                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-23915 │ MEDIUM   │                   │               │ curl: HSTS amnesia with --parallel                           │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-23915                   │
├────────────┼────────────────┼──────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ git        │ CVE-2022-23521 │ CRITICAL │ 2.38.2-r0         │ 2.38.3-r0     │ git: gitattributes parsing integer overflow                  │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-23521                   │
│            ├────────────────┤          │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2022-41903 │          │                   │               │ git: Heap overflow in `git archive`, `git log --format`      │
│            │                │          │                   │               │ leading to RCE...                                            │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-41903                   │
│            ├────────────────┼──────────┤                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-23946 │ HIGH     │                   │ 2.38.4-r0     │ git: git apply: a path outside the working tree can be       │
│            │                │          │                   │               │ overwritten...                                               │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-23946                   │
│            ├────────────────┼──────────┤                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-22490 │ MEDIUM   │                   │               │ git: data exfiltration with maliciously crafted repository   │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-22490                   │
├────────────┼────────────────┼──────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2022-4450  │ HIGH     │ 3.0.7-r2          │ 3.0.8-r0      │ openssl: double free after calling PEM_read_bio_ex           │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4450                    │
│            ├────────────────┤          │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0215  │          │                   │               │ openssl: use-after-free following BIO_new_NDEF               │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0215                    │
│            ├────────────────┤          │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0216  │          │                   │               │ openssl: invalid pointer dereference in d2i_PKCS7 functions  │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0216                    │
│            ├────────────────┤          │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0217  │          │                   │               │ openssl: NULL dereference validating DSA public key          │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0217                    │
│            ├────────────────┤          │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0286  │          │                   │               │ openssl: X.400 address type confusion in X.509 GeneralName   │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0286                    │
│            ├────────────────┤          │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0401  │          │                   │               │ openssl: NULL dereference during PKCS7 data verification     │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0401                    │
│            ├────────────────┼──────────┤                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2022-4203  │ MEDIUM   │                   │               │ openssl: read buffer overflow in X.509 certificate           │
│            │                │          │                   │               │ verification                                                 │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4203                    │
│            ├────────────────┤          │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2022-4304  │          │                   │               │ openssl: timing attack in RSA Decryption implementation      │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4304                    │
├────────────┼────────────────┼──────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libcurl    │ CVE-2023-23914 │ CRITICAL │ 7.87.0-r1         │ 7.87.0-r2     │ curl: HSTS ignored on multiple requests                      │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-23914                   │
│            ├────────────────┼──────────┤                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-23916 │ HIGH     │                   │               │ curl: HTTP multi-header compression denial of service        │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-23916                   │
│            ├────────────────┼──────────┤                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-23915 │ MEDIUM   │                   │               │ curl: HSTS amnesia with --parallel                           │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-23915                   │
├────────────┼────────────────┼──────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libssl3    │ CVE-2022-4450  │ HIGH     │ 3.0.7-r2          │ 3.0.8-r0      │ openssl: double free after calling PEM_read_bio_ex           │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4450                    │
│            ├────────────────┤          │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0215  │          │                   │               │ openssl: use-after-free following BIO_new_NDEF               │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0215                    │
│            ├────────────────┤          │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0216  │          │                   │               │ openssl: invalid pointer dereference in d2i_PKCS7 functions  │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0216                    │
│            ├────────────────┤          │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0217  │          │                   │               │ openssl: NULL dereference validating DSA public key          │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0217                    │
│            ├────────────────┤          │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0286  │          │                   │               │ openssl: X.400 address type confusion in X.509 GeneralName   │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0286                    │
│            ├────────────────┤          │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0401  │          │                   │               │ openssl: NULL dereference during PKCS7 data verification     │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0401                    │
│            ├────────────────┼──────────┤                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2022-4203  │ MEDIUM   │                   │               │ openssl: read buffer overflow in X.509 certificate           │
│            │                │          │                   │               │ verification                                                 │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4203                    │
│            ├────────────────┤          │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2022-4304  │          │                   │               │ openssl: timing attack in RSA Decryption implementation      │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4304                    │
├────────────┼────────────────┼──────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ nodejs     │ CVE-2023-23918 │ HIGH     │ 18.12.1-r0        │ 18.14.1-r0    │ Node.js: Permissions policies can be bypassed via            │
│            │                │          │                   │               │ process.mainModule                                           │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-23918                   │
│            ├────────────────┤          │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-23919 │          │                   │               │ Node.js: OpenSSL error handling issues in nodejs crypto      │
│            │                │          │                   │               │ library                                                      │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-23919                   │
│            ├────────────────┤          │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-24807 │          │                   │               │ Node.js: Regular Expression Denial of Service in Headers     │
│            │                │          │                   │               │ fetch API                                                    │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-24807                   │
│            ├────────────────┼──────────┤                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-23920 │ MEDIUM   │                   │               │ Node.js: insecure loading of ICU data through ICU_DATA       │
│            │                │          │                   │               │ environment variable                                         │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-23920                   │
│            ├────────────────┤          │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-23936 │          │                   │               │ Node.js: Fetch API did not protect against CRLF injection in │
│            │                │          │                   │               │ host headers...                                              │
│            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-23936                   │
└────────────┴────────────────┴──────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────────────────┘
2023-03-06T10:49:07.653+0100	INFO	Table result includes only package filenames. Use '--format json' option to get the full path to the package file.

Node.js (node-pkg)

Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 0)

┌─────────────────────────────────────┬────────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│               Library               │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                           Title                            │
├─────────────────────────────────────┼────────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ http-cache-semantics (package.json) │ CVE-2022-25881 │ HIGH     │ 4.1.0             │ 4.1.1         │ http-cache-semantics: Regular Expression Denial of Service │
│                                     │                │          │                   │               │ (ReDoS) vulnerability                                      │
│                                     │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-25881                 │
└─────────────────────────────────────┴────────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘
```

</p>
</details>



### After Image update:
```bash
ᐅ  docker build . -t kth-node-16-alpine-updated && docker run kth-node-16-alpine-updated cat /KTH_NODEJS

IMAGE INFORMATION
Based on:  node:16-alpine
Build date: Mon Mar  6 08:55:09 UTC 2023
Node: v16.19.1
NPM: 9.6.0
Yarn: 1.22.19

--- Default global packages ---
/usr/local/lib
+-- corepack@0.17.0
+-- merge-descriptors@1.0.1
`-- npm@9.6.0
```

### Results
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

<details><summary>Scan details</summary>
<p>

```ruby
ᐅ  trivy image kth-node-16-alpine-updated

2023-03-06T10:55:27.445+0100	INFO	Vulnerability scanning is enabled
2023-03-06T10:55:27.445+0100	INFO	Secret scanning is enabled
2023-03-06T10:55:27.445+0100	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-03-06T10:55:27.445+0100	INFO	Please see also https://aquasecurity.github.io/trivy/v0.38/docs/secret/scanning/#recommendation for faster secret detection
2023-03-06T10:55:27.463+0100	INFO	Detected OS: alpine
2023-03-06T10:55:27.463+0100	INFO	Detecting Alpine vulnerabilities...
2023-03-06T10:55:27.465+0100	INFO	Number of language-specific files: 1
2023-03-06T10:55:27.465+0100	INFO	Detecting node-pkg vulnerabilities...

kth-node-16-alpine-updated (alpine 3.17.2)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```
</p>
</details>